### PR TITLE
fix(docs): link to the actual git repo in the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This process assumes a Linux machine. On Windows, use WSL.
 
 2. Clone the repository:
    ```bash
-   git clone --recurse-submodules https://github.com/worproject/rpi5-uefi.git
+   git clone --recurse-submodules https://github.com/NumberOneGit/rpi5-uefi.git
    cd rpi5-uefi
    ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions with the correct repository clone URL for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->