### PR TITLE
Add uuid-dev to build pipeline dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           device-tree-compiler \
           gettext \
           git \
+          uuid-dev \
           gcc-aarch64-linux-gnu \
           libc6-dev-arm64-cross \
           python3 \


### PR DESCRIPTION
When running the build pipeline to produce artifacts I noticed uuid-dev was missing causing a [build error](https://github.com/michiel-schoofs/rpi5-uefi/actions/runs/25216208397). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow dependencies.

---

**Note:** This release contains only internal infrastructure updates with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->